### PR TITLE
feat: add offline KitAI endpoint and Stripe webhook with telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,45 @@
 # etoolkit
+
+## Supabase Edge Functions
+
+### Deploy KitAI and Stripe Webhook
+
+```bash
+supabase functions deploy kitai
+supabase functions deploy stripe-webhook
+```
+
+### Set Secrets
+
+```bash
+supabase secrets set STRIPE_WEBHOOK_SECRET=whsec_...
+```
+
+### Stripe Webhook Configuration
+
+Create an endpoint in the Stripe dashboard pointing to:
+
+```
+https://<project-ref>.functions.supabase.co/stripe-webhook
+```
+
+Send test events and ensure valid signatures.
+
+## EAS Build (iOS dev)
+
+```bash
+expo login
+cd apps/mobile
+eas init --id <project-id-if-any>
+eas secret:create --scope project --name EXPO_PUBLIC_SUPABASE_URL --value https://<ref>.supabase.co
+eas secret:create --scope project --name EXPO_PUBLIC_SUPABASE_ANON_KEY --value <anon>
+eas build -p ios --profile development
+```
+
+## Tests
+
+Run unit tests with:
+
+```bash
+npm test
+```

--- a/apps/mobile/app/(tabs)/assistant.tsx
+++ b/apps/mobile/app/(tabs)/assistant.tsx
@@ -1,0 +1,35 @@
+import React, { useMemo, useState } from 'react';
+import { View, Text, TextInput, Pressable, FlatList } from 'react-native';
+import { askKitAI } from '../../lib/kitai';
+
+export default function Assistant() {
+  const [log, setLog] = useState<{ role:'user'|'assistant'; text:string }[]>([
+    { role: 'assistant', text: 'KitAI ready. Ask: overdue invoices, totals today, quick picks, or client <name> email.' }
+  ]);
+  const [input, setInput] = useState('');
+  const host = useMemo(()=> 'https://<your-ref>.functions.supabase.co', []); // put your project ref here or derive from config
+
+  const send = async () => {
+    const q = input.trim(); if (!q) return;
+    setLog((l)=> [...l, { role:'user', text:q }]); setInput('');
+    const a = await askKitAI(host, q);
+    setLog((l)=> [...l, { role:'assistant', text:a }]);
+  };
+
+  return (
+    <View style={{ flex:1, padding: 16 }}>
+      <Text style={{ fontSize: 24, fontWeight: '700' }}>KitAI</Text>
+      <FlatList data={log} keyExtractor={(_,i)=>`m-${i}`} renderItem={({item})=> (
+        <View style={{ alignSelf: item.role==='user'?'flex-end':'flex-start', backgroundColor: item.role==='user'?'#111':'#eee', padding: 10, borderRadius: 12, marginTop: 8 }}>
+          <Text style={{ color: item.role==='user'?'#fff':'#111' }}>{item.text}</Text>
+        </View>
+      )} />
+      <View style={{ flexDirection:'row', gap: 8, marginTop: 8 }}>
+        <TextInput value={input} onChangeText={setInput} placeholder="Ask KitAI…" style={{ flex:1, borderWidth:1, borderRadius:12, padding:10 }} />
+        <Pressable onPress={send} style={{ backgroundColor:'black', paddingHorizontal: 16, borderRadius: 12, justifyContent:'center' }}>
+          <Text style={{ color:'#fff', fontWeight:'600' }}>Send</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,0 +1,8 @@
+import React, { useEffect } from 'react';
+import { Slot } from 'expo-router';
+import { initTelemetry } from '../lib/telemetry';
+
+export default function RootLayout() {
+  useEffect(() => { initTelemetry(); }, []);
+  return <Slot />;
+}

--- a/apps/mobile/lib/kitai.ts
+++ b/apps/mobile/lib/kitai.ts
@@ -1,0 +1,7 @@
+export async function askKitAI(host: string, question: string): Promise<string> {
+  try {
+    const res = await fetch(`${host}/kitai`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ question }) });
+    if (res.ok) { const j = await res.json(); return j.answer || '…'; }
+  } catch {}
+  return 'Try: “Show overdue invoices”, “Totals today”, “List quick picks”, or “Client <name> email”.';
+}

--- a/apps/mobile/lib/telemetry.ts
+++ b/apps/mobile/lib/telemetry.ts
@@ -1,0 +1,17 @@
+// No‑op if keys are missing. Call initTelemetry() once in the app root.
+export function initTelemetry() {
+  try {
+    // Optional: Sentry
+    // @ts-ignore - import only if added to project
+    // Sentry.init({ dsn: process.env.SENTRY_DSN, enableNative: true });
+  } catch {}
+}
+
+export function track(event: string, props?: Record<string, any>) {
+  try {
+    // Optional: PostHog
+    // posthog?.capture?.(event, props);
+    // Fallback console log in dev
+    if (__DEV__) console.log('[track]', event, props || {});
+  } catch {}
+}

--- a/supabase/functions/kitai/index.ts
+++ b/supabase/functions/kitai/index.ts
@@ -1,0 +1,19 @@
+Deno.serve(async (req) => {
+  try {
+    if (req.method !== 'POST') return new Response('Method Not Allowed', { status: 405 });
+    const body = await req.json().catch(() => ({}));
+    const q: string = (body?.question || '').toLowerCase().trim();
+    const reply = (() => {
+      if (!q) return "Try: ‘Show overdue invoices’, ‘List quick picks’, ‘Totals today’, or ‘Client <name> email’.";
+      if (q.includes('overdue')) return 'No overdue invoices detected in this M1 build.';
+      if (q.includes('quick pick')) return 'Quick Picks: Hose bib replacement ($50), Outlet install GFCI ($85), Drain snaking ($120), Thermostat swap ($75).';
+      if (q.includes('totals') && q.includes('today')) return 'Estimated totals today: compute from History in a future update.';
+      const m = q.match(/client\s+([^\s]+)\s+email/);
+      if (m) return `Open the Clients tab and search for “${m[1]}” to view contact details.`;
+      return "I can help with: overdue invoices, totals today, quick picks, or ‘client <name> email’.";
+    })();
+    return new Response(JSON.stringify({ answer: reply }), { headers: { 'Content-Type': 'application/json' } });
+  } catch (e) {
+    return new Response(`Error: ${e?.message || 'unknown'}`, { status: 500 });
+  }
+});

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -1,0 +1,20 @@
+import Stripe from 'npm:stripe@^14.0.0';
+
+const stripe = new Stripe('sk_test_123', { apiVersion: '2024-06-20' });
+
+Deno.serve(async (req) => {
+  try {
+    const whsec = Deno.env.get('STRIPE_WEBHOOK_SECRET');
+    if (!whsec) return new Response('Missing STRIPE_WEBHOOK_SECRET', { status: 500 });
+
+    const sig = req.headers.get('stripe-signature') || '';
+    const raw = await req.text();
+
+    const event = stripe.webhooks.constructEvent(raw, sig, whsec);
+    console.log(JSON.stringify({ id: event.id, type: event.type }));
+
+    return new Response(JSON.stringify({ ok: true }), { headers: { 'Content-Type': 'application/json' } });
+  } catch (err: any) {
+    return new Response(`Invalid signature: ${err.message || 'unknown'}`, { status: 400 });
+  }
+});

--- a/tests/kitai-keywords.test.ts
+++ b/tests/kitai-keywords.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+
+function classify(q: string): string {
+  q = q.toLowerCase();
+  if (q.includes('quick pick')) return 'quick';
+  if (q.includes('overdue')) return 'overdue';
+  if (q.includes('totals') && q.includes('today')) return 'totals';
+  if (/client\s+[^\s]+\s+email/.test(q)) return 'client-email';
+  return 'help';
+}
+
+describe('kitai keywords', () => {
+  it('detects quick picks', ()=> expect(classify('List QUICK PICKS')).toBe('quick'));
+  it('detects overdue', ()=> expect(classify('Any overdue invoices?')).toBe('overdue'));
+  it('detects totals today', ()=> expect(classify('What are the totals today')).toBe('totals'));
+  it('detects client email pattern', ()=> expect(classify('client Jane email')).toBe('client-email'));
+  it('falls back to help', ()=> expect(classify('hello')).toBe('help'));
+});


### PR DESCRIPTION
## Summary
- add KitAI edge function with canned responses for offline prompts
- add Stripe webhook function verifying signatures
- add Expo KitAI client, assistant UI, and telemetry helpers
- add keyword classification tests and update README with deployment/build docs

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f6e4c227883228795fa0e9dee3a54