### PR TITLE
feat: add scheduling components and realtime support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # etoolkit
+
+## Realtime
+
+Enable Supabase Realtime and filter by organization. Subscribe to channels like `org:<orgId>` to receive updates for `schedule_events`, `jobs`, and `task_items`.
+
+## iOS motion / performance
+
+Use lightweight animations and haptics to maintain a native feel. Test on device to ensure smooth performance.

--- a/apps/mobile/app/(tabs)/schedule.tsx
+++ b/apps/mobile/app/(tabs)/schedule.tsx
@@ -1,0 +1,87 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { View, Text, Pressable, FlatList, Modal, TextInput, Alert, ActivityIndicator } from 'react-native';
+import { useOrg } from '../../lib/org';
+import { listEventsByDay, createEvent } from '../../features/schedule/api';
+import { dayBoundsISO } from '../../lib/date';
+import WeekStrip from '../../components/WeekStrip';
+import EventCard from '../../components/EventCard';
+import { subscribeOrg } from '../../features/realtime';
+import { useRouter } from 'expo-router';
+
+export default function Schedule() {
+  const { orgId } = useOrg();
+  const [date, setDate] = useState(new Date());
+  const [events, setEvents] = useState<any[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [modal, setModal] = useState(false);
+  const [form, setForm] = useState({ job_id: '', starts: '', ends: '', note: '' });
+  const router = useRouter();
+
+  const bounds = useMemo(()=> dayBoundsISO(date), [date]);
+
+  const load = useCallback(async () => {
+    if (!orgId) return;
+    setLoading(true);
+    try { const rows = await listEventsByDay(orgId, bounds.startISO, bounds.endISO); setEvents(rows); }
+    catch (e:any) { Alert.alert('Load failed', e.message||''); }
+    finally { setLoading(false); }
+  }, [orgId, bounds.startISO]);
+
+  useEffect(()=>{ load(); }, [load]);
+
+  useEffect(()=>{
+    if (!orgId) return;
+    return subscribeOrg(orgId, (p)=>{
+      if (p.table==='schedule_events') load();
+      if (p.table==='jobs') load();
+    });
+  }, [orgId, load]);
+
+  const create = async () => {
+    try {
+      if (!orgId) return;
+      const payload = { org_id: orgId, job_id: form.job_id, starts_at: form.starts, ends_at: form.ends, note: form.note };
+      await createEvent(payload);
+      setModal(false); setForm({ job_id:'', starts:'', ends:'', note:'' });
+      load();
+    } catch (e:any) {
+      setModal(false);
+      Alert.alert('Failed', e.message||'Unknown error');
+    }
+  };
+
+  return (
+    <View style={{ flex:1, padding:16 }}>
+      <Text style={{ fontSize:24, fontWeight:'700' }}>Schedule</Text>
+      <WeekStrip date={date} onChange={setDate} />
+
+      {loading ? <ActivityIndicator/> : (
+        <FlatList data={events} keyExtractor={(e)=> e.id} renderItem={({item})=> (
+          <EventCard item={item} onPress={()=> router.push(`/job/${item.job_id}`)} />
+        )} />
+      )}
+
+      <Pressable onPress={()=> setModal(true)} style={{ marginTop:12, backgroundColor:'black', padding:12, borderRadius:12, alignSelf:'flex-start' }}>
+        <Text style={{ color:'#fff', fontWeight:'600' }}>New Event</Text>
+      </Pressable>
+
+      <Modal visible={modal} transparent animationType='fade'>
+        <View style={{ flex:1, backgroundColor:'rgba(0,0,0,0.5)', justifyContent:'center', padding:16 }}>
+          <View style={{ backgroundColor:'white', borderRadius:16, padding:16 }}>
+            <Text style={{ fontSize:18, fontWeight:'700', marginBottom:8 }}>New Event</Text>
+            <TextInput placeholder='Job ID' value={form.job_id} onChangeText={(t)=> setForm({ ...form, job_id: t })} style={{ borderWidth:1, borderRadius:12, padding:10, marginBottom:8 }} />
+            <TextInput placeholder='Start (ISO)' value={form.starts} onChangeText={(t)=> setForm({ ...form, starts: t })} style={{ borderWidth:1, borderRadius:12, padding:10, marginBottom:8 }} />
+            <TextInput placeholder='End (ISO)' value={form.ends} onChangeText={(t)=> setForm({ ...form, ends: t })} style={{ borderWidth:1, borderRadius:12, padding:10, marginBottom:8 }} />
+            <TextInput placeholder='Note' value={form.note} onChangeText={(t)=> setForm({ ...form, note: t })} style={{ borderWidth:1, borderRadius:12, padding:10 }} />
+            <View style={{ flexDirection:'row', justifyContent:'flex-end', gap:12, marginTop:12 }}>
+              <Pressable onPress={()=> setModal(false)}><Text>Cancel</Text></Pressable>
+              <Pressable onPress={create} style={{ backgroundColor:'black', paddingHorizontal:14, paddingVertical:10, borderRadius:12 }}>
+                <Text style={{ color:'#fff', fontWeight:'600' }}>Save</Text>
+              </Pressable>
+            </View>
+          </View>
+        </View>
+      </Modal>
+    </View>
+  );
+}

--- a/apps/mobile/app/job/[id].tsx
+++ b/apps/mobile/app/job/[id].tsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, FlatList, Pressable, TextInput, Alert } from 'react-native';
+import { useLocalSearchParams } from 'expo-router';
+import TaskItem from '../../components/TaskItem';
+import { addTask, listTasks, toggleTask, reorderTasks } from '../../features/tasks/api';
+
+export default function JobDetail() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const [tasks, setTasks] = useState<any[]>([]);
+  const [input, setInput] = useState('');
+
+  const load = async ()=> {
+    const rows = await listTasks(id as string); setTasks(rows);
+  };
+  useEffect(()=>{ if (id) load(); }, [id]);
+
+  const onAdd = async ()=> {
+    try { await addTask(id as string, input); setInput(''); load(); }
+    catch (e:any) { Alert.alert('Failed', e.message||''); }
+  };
+
+  const onToggle = async (tid: string, done: boolean)=> {
+    try { await toggleTask(tid, done); load(); } catch(e:any){ Alert.alert('Failed', e.message||''); }
+  };
+
+  return (
+    <View style={{ flex:1, padding:16 }}>
+      <Text style={{ fontSize:22, fontWeight:'700' }}>Job</Text>
+      <Text style={{ marginTop:12, fontWeight:'600' }}>Tasks</Text>
+      <FlatList data={tasks} keyExtractor={(t)=> t.id} renderItem={({item})=> (
+        <TaskItem item={item} onToggle={()=> onToggle(item.id, !item.done)} />
+      )} />
+      <View style={{ flexDirection:'row', gap:8 }}>
+        <TextInput placeholder='New task' value={input} onChangeText={setInput} style={{ flex:1, borderWidth:1, borderRadius:12, padding:10 }} />
+        <Pressable onPress={onAdd} style={{ backgroundColor:'black', padding:12, borderRadius:12 }}><Text style={{ color:'#fff', fontWeight:'600' }}>Add</Text></Pressable>
+      </View>
+    </View>
+  );
+}

--- a/apps/mobile/components/EventCard.tsx
+++ b/apps/mobile/components/EventCard.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { View, Text, Pressable } from 'react-native';
+
+type Props = { item: any; onPress?: ()=>void };
+export default function EventCard({ item, onPress }: Props) {
+  const start = new Date(item.starts_at); const end = new Date(item.ends_at);
+  const time = `${start.toLocaleTimeString([], { hour:'2-digit', minute:'2-digit' })} – ${end.toLocaleTimeString([], { hour:'2-digit', minute:'2-digit' })}`;
+  const color = item.job_status==='IN_PROGRESS' ? '#0ea5e9' : item.job_status==='COMPLETE' ? '#22c55e' : '#111';
+  return (
+    <Pressable onPress={onPress} style={{ paddingVertical:12, borderBottomWidth:1, borderColor:'#eee' }}>
+      <Text style={{ fontWeight:'700', color }}>{item.job_title || 'Job'}</Text>
+      <Text style={{ opacity:.7 }}>{time}</Text>
+      {item.note ? <Text>{item.note}</Text> : null}
+    </Pressable>
+  );
+}

--- a/apps/mobile/components/TaskItem.tsx
+++ b/apps/mobile/components/TaskItem.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { View, Text, Pressable } from 'react-native';
+
+type Props = { item: any; onToggle: ()=>void; dragHandle?: React.ReactNode };
+export default function TaskItem({ item, onToggle, dragHandle }: Props) {
+  return (
+    <View style={{ flexDirection:'row', alignItems:'center', gap:12, paddingVertical:10 }}>
+      {dragHandle}
+      <Pressable onPress={onToggle} style={{ height:22, width:22, borderRadius:6, borderWidth:1, borderColor:'#ccc', backgroundColor: item.done?'#111':'transparent' }} />
+      <Text style={{ flex:1, textDecorationLine: item.done?'line-through':'none' }}>{item.title}</Text>
+    </View>
+  );
+}

--- a/apps/mobile/components/WeekStrip.tsx
+++ b/apps/mobile/components/WeekStrip.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { View, Text, Pressable } from 'react-native';
+import * as Haptics from 'expo-haptics';
+
+type Props = { date: Date; onChange: (d: Date)=>void };
+export default function WeekStrip({ date, onChange }: Props) {
+  const start = new Date(date); const day = start.getDay();
+  const diff = (day + 6) % 7; // make Monday=0
+  start.setDate(start.getDate() - diff);
+  const days = Array.from({ length: 7 }, (_,i)=> new Date(start.getFullYear(), start.getMonth(), start.getDate()+i));
+  const same = (a:Date,b:Date)=> a.toDateString()===b.toDateString();
+  return (
+    <View style={{ flexDirection:'row', gap:8, marginVertical:8 }}>
+      {days.map(d=>{
+        const active = same(d, date);
+        return (
+          <Pressable key={d.toDateString()} onPress={()=>{ onChange(new Date(d)); Haptics.selectionAsync(); }} style={{ paddingHorizontal:10, paddingVertical:8, borderRadius:12, backgroundColor: active?'black':'#f2f2f2' }}>
+            <Text style={{ color: active?'#fff':'#111', fontWeight:'700' }}>{d.getDate()}</Text>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}

--- a/apps/mobile/features/realtime/index.ts
+++ b/apps/mobile/features/realtime/index.ts
@@ -1,0 +1,11 @@
+import { supabase } from '../../lib/supabase';
+
+export function subscribeOrg(orgId: string, onEvent: (payload:{ table:string; type:string; new:any; old:any })=>void) {
+  const ch = supabase
+    .channel(`org:${orgId}`)
+    .on('postgres_changes', { event: '*', schema: 'public', table: 'schedule_events', filter: `org_id=eq.${orgId}` }, (p)=> onEvent({ table:'schedule_events', type:p.eventType, new:(p as any).new, old:(p as any).old }))
+    .on('postgres_changes', { event: '*', schema: 'public', table: 'jobs' }, (p)=> onEvent({ table:'jobs', type:p.eventType, new:(p as any).new, old:(p as any).old }))
+    .on('postgres_changes', { event: '*', schema: 'public', table: 'task_items' }, (p)=> onEvent({ table:'task_items', type:p.eventType, new:(p as any).new, old:(p as any).old }))
+    .subscribe();
+  return () => { supabase.removeChannel(ch); };
+}

--- a/apps/mobile/features/tasks/api.ts
+++ b/apps/mobile/features/tasks/api.ts
@@ -1,0 +1,24 @@
+import { supabase } from '../../lib/supabase';
+
+export type TaskInput = { job_id: string; title: string };
+
+export async function addTask(job_id: string, title: string) {
+  const { data, error } = await supabase.from('task_items').insert({ job_id, title }).select('id').single();
+  if (error) throw error; return data!.id as string;
+}
+
+export async function toggleTask(id: string, done: boolean) {
+  const { error } = await supabase.from('task_items').update({ done }).eq('id', id);
+  if (error) throw error;
+}
+
+export async function reorderTasks(job_id: string, orderedIds: string[]) {
+  const updates = orderedIds.map((id, idx)=> ({ id, order_index: idx*10 }));
+  const { error } = await supabase.from('task_items').upsert(updates, { onConflict: 'id' });
+  if (error) throw error;
+}
+
+export async function listTasks(job_id: string) {
+  const { data, error } = await supabase.from('task_items').select('*').eq('job_id', job_id).order('order_index');
+  if (error) throw error; return data||[];
+}

--- a/apps/mobile/lib/offline.ts
+++ b/apps/mobile/lib/offline.ts
@@ -1,0 +1,4 @@
+export function hasConflict(localVersion: number|undefined, remoteVersion: number|undefined) {
+  if (localVersion==null || remoteVersion==null) return false;
+  return localVersion < remoteVersion; // server is newer than what we edited
+}

--- a/apps/mobile/lib/overlap.ts
+++ b/apps/mobile/lib/overlap.ts
@@ -1,0 +1,3 @@
+export function overlaps(aStart:Date, aEnd:Date, bStart:Date, bEnd:Date) {
+  return aStart < bEnd && bStart < aEnd; // strict overlap
+}

--- a/apps/mobile/lib/reorder.ts
+++ b/apps/mobile/lib/reorder.ts
@@ -1,0 +1,3 @@
+export function normalizeOrder(ids: string[]) {
+  return ids.map((id, i)=> ({ id, order_index: i*10 }));
+}

--- a/supabase/sql/m3s2_indices_views.sql
+++ b/supabase/sql/m3s2_indices_views.sql
@@ -1,0 +1,31 @@
+-- 1) Fast day queries
+create index if not exists idx_events_org_range on schedule_events(org_id, starts_at, ends_at);
+
+-- 2) Jobs quick lookup for calendar hydration
+create view if not exists v_events_hydrated as
+  select e.id, e.org_id, e.job_id, e.assignee_user_id,
+         e.starts_at, e.ends_at, e.note,
+         j.title as job_title, j.status as job_status
+  from schedule_events e
+  join jobs j on j.id = e.job_id;
+
+-- 3) Optimistic concurrency: add version columns
+alter table schedule_events add column if not exists version int not null default 0;
+alter table jobs add column if not exists version int not null default 0;
+alter table task_items add column if not exists version int not null default 0;
+
+-- Trigger to bump version on updates
+create or replace function bump_version() returns trigger as $$
+begin
+  new.version := old.version + 1;
+  return new;
+end; $$ language plpgsql;
+
+drop trigger if exists trg_events_bump on schedule_events;
+create trigger trg_events_bump before update on schedule_events for each row execute function bump_version();
+
+drop trigger if exists trg_jobs_bump on jobs;
+create trigger trg_jobs_bump before update on jobs for each row execute function bump_version();
+
+drop trigger if exists trg_tasks_bump on task_items;
+create trigger trg_tasks_bump before update on task_items for each row execute function bump_version();

--- a/supabase/sql/m3s2_rls_amend.sql
+++ b/supabase/sql/m3s2_rls_amend.sql
@@ -1,0 +1,5 @@
+-- Allow select on view via underlying table policies (no direct RLS needed on view)
+-- Ensure realtime works: grants are handled at table level; nothing extra if Realtime is enabled for schema.
+
+-- Update policies to permit versioned updates (no change needed functionally; optimistic check is app-side).
+-- (If you added extra policies earlier, keep them.)

--- a/tests/event-overlap.test.ts
+++ b/tests/event-overlap.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { overlaps } from '../apps/mobile/lib/overlap';
+
+describe('overlaps', ()=>{
+  const d = (h:number,m=0)=> new Date(2025,0,1,h,m,0,0);
+  it('detects overlap', ()=>{
+    expect(overlaps(d(9),d(10),d(9,30),d(10,30))).toBeTruthy();
+  });
+});

--- a/tests/task-reorder.test.ts
+++ b/tests/task-reorder.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeOrder } from '../apps/mobile/lib/reorder';
+
+describe('normalizeOrder', ()=>{
+  it('spaces by ten', ()=>{
+    const out = normalizeOrder(['a','b','c']);
+    expect(out.map(o=>o.order_index)).toEqual([0,10,20]);
+  });
+});

--- a/tests/version-merge.test.ts
+++ b/tests/version-merge.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { hasConflict } from '../apps/mobile/lib/offline';
+
+describe('hasConflict', ()=>{
+  it('flags when server newer', ()=>{
+    expect(hasConflict(2,3)).toBe(true);
+  });
+  it('no conflict when same', ()=>{
+    expect(hasConflict(3,3)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add SQL indexes, hydrated view, and optimistic versioning triggers
- introduce mobile components and realtime channel subscriptions
- implement task checklist and conflict detection helper

## Testing
- `npx --yes vitest run`


------
https://chatgpt.com/codex/tasks/task_e_689f73c4f8dc83229188e5c07d35a89d